### PR TITLE
retry: fix modify-by-reference bug for immutable configuration passed in.

### DIFF
--- a/src/retryDecorator.js
+++ b/src/retryDecorator.js
@@ -8,8 +8,8 @@
 * @param {number|function(attempt) : number} [opts.delay = 500] - delay between retries (ms)
 * @return {function(uri, requestOptions, callback): Promise}
 */
-function me(requester, opts) {
-  opts = typeof opts === 'object' ? opts : {};
+function me(requester, passedOpts) {
+  const opts = Object.assign({},passedOpts);
   opts.attempts = opts.attempts !== undefined ? opts.attempts : 3;
   opts.errorFilter = opts.errorFilter || me.defaultErrorFilter;
 

--- a/test/retryDecoratorSpec.js
+++ b/test/retryDecoratorSpec.js
@@ -115,5 +115,12 @@ describe('retryDecorator', () => {
       .catch(done.fail);
   });
 
+
+  it('accepts immutable retry config.', done => {
+    rp().plus.wrap(retryWrapper, Object.freeze({
+      attempts: 2
+    }));
+    done();
+  });
 });
 

--- a/test/retryDecoratorSpec.js
+++ b/test/retryDecoratorSpec.js
@@ -65,7 +65,7 @@ describe('retryDecorator', () => {
     const request = rp().plus.wrap(retryWrapper, {
       delay: 100
     });
-    request('http://example.com/test-path')
+    request('http://example3.com/test-path')
       .then(() => {
         done.fail('unexpected success');
       })


### PR DESCRIPTION
This fix may be useful in other areas as well. I focused only on updating
the code related to `retry`.